### PR TITLE
Fix modifier ordering for TAB_PREV/TAB_NEXT on macOS

### DIFF
--- a/shared/macros.dtsi
+++ b/shared/macros.dtsi
@@ -19,3 +19,5 @@ MACRO(vill, &kp LC(A) &kp LS(Q))
 /* Window */
 MACRO(back, &macro_press &kp LALT &macro_tap &kp LEFT &macro_release &kp LALT)
 MACRO(forward, &macro_press &kp LALT &macro_tap &kp RIGHT &macro_release &kp LALT)
+MACRO(tab_prev, &macro_press &kp LCTRL &macro_tap &kp PG_UP &macro_release &kp LCTRL)
+MACRO(tab_next, &macro_press &kp LCTRL &macro_tap &kp PG_DN &macro_release &kp LCTRL)

--- a/totem/totem.h
+++ b/totem/totem.h
@@ -21,8 +21,8 @@
 #define XXX         &none
 #define ___         &trans
 #define MEH         LC(LS(LALT))        // Left Alt + Ctrl
-#define TAB_PREV    &kp LC(PG_UP)       // Previous tab
-#define TAB_NEXT    &kp LC(PG_DN)       // Next tab
+#define TAB_PREV    &m_tab_prev         // Previous tab
+#define TAB_NEXT    &m_tab_next         // Next tab
 #define CLeft       &kp LC(LEFT)        // CTRL + Left arrow
 #define CRight      &kp LC(RIGHT)       // CTRL + Right arrow
 #define NEXT        &kp LC(K)           // Next occurance


### PR DESCRIPTION
… on macOS

Replace &kp LC(PG_UP/PG_DN) with explicit macro sequences that press the modifier before the key, matching the pattern used by m_back and m_forward.